### PR TITLE
Simplify FAISS setup and pin NumPy

### DIFF
--- a/Clinicalv1_1.ipynb
+++ b/Clinicalv1_1.ipynb
@@ -58,8 +58,8 @@
         "source /content/fhir_env/bin/activate\n",
         "pip install --quiet --upgrade pip\n",
         "\n",
-        "# core libs (NumPy 2.0, PyTorch 2.3 CUDA 12, etc.)\n",
-        "pip install --quiet numpy==2.0.0 \\\n",
+        "# core libs (NumPy<2 for compatibility, PyTorch 2.3 CUDA 12, etc.)\n",
+        "pip install --quiet \"numpy<2\" \\\n",
         "    --extra-index-url https://download.pytorch.org/whl/cu121 \\\n",
         "    torch==2.3.0 torchvision==0.18.0\n",
         "\n",
@@ -150,7 +150,7 @@
       "source": [
         "%%bash\n",
         "source /content/fhir_env/bin/activate\n",
-        "pip install --upgrade --force-reinstall \"numpy==2.0.0\""
+        "pip install --upgrade --force-reinstall \"numpy<2\""
       ],
       "metadata": {
         "colab": {
@@ -669,29 +669,10 @@
     {
       "cell_type": "code",
       "source": [
-        "import site, sys, pathlib\n",
-        "VENV = \"/content/fhir_env\"\n",
-        "sp   = next(pathlib.Path(VENV).rglob(\"site-packages\"))\n",
-        "if str(sp) not in sys.path:\n",
-        "    sys.path.insert(0, str(sp))\n",
-        "\n",
-        "import importlib.util, types\n",
-        "spec = importlib.util.find_spec(\"_swigfaiss\")\n",
-        "if spec is None:\n",
-        "    candidate = \"/content/faiss/build/faiss/python\"\n",
-        "    if candidate not in sys.path:\n",
-        "        sys.path.insert(0, candidate)\n",
-        "    spec = importlib.util.find_spec(\"_swigfaiss\")\n",
-        "if spec is None:\n",
-        "    raise ImportError(\"Cannot find _swigfaiss.so – did the build succeed?\")\n",
-        "\n",
-        "_swf  = importlib.import_module(\"_swigfaiss\")\n",
-        "faiss = types.ModuleType(\"faiss\")\n",
-        "for name in dir(_swf):\n",
-        "    if not name.startswith(\"__\"):\n",
-        "        setattr(faiss, name, getattr(_swf, name))\n",
-        "sys.modules[\"faiss\"] = faiss\n",
-        "print(\"Patched faiss facade with\", len(dir(faiss)), \"symbols\")"
+        "import sys",
+        "sys.path.insert(0, \"/content/faiss/build/faiss/python\")",
+        "import faiss",
+        "print(\"faiss imported\", faiss.__version__)"
       ],
       "metadata": {
         "colab": {

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ The software should do the following:
 -) All diagnosis, decision, etc. made by the LLM should be presented to the user in a form, that allows for direct checking of the information and the sources used by the LLM
 
 The model used for the embedding and LLM should be open-source and be able to run on the Google Colab Platform directly. The specs are: A100 GPU, having 83.5GB of System-RAM, 40GB of GPU-RAM, and 180GB of storage.
+
+## Notes
+This project currently uses `numpy<2` to avoid compatibility issues when compiling dependencies like Faiss.


### PR DESCRIPTION
## Summary
- install `numpy<2` instead of using 2.x
- keep environment simple by importing FAISS from build directory
- document NumPy requirement in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877bd705b54832082c2a1b7c8435372